### PR TITLE
fix: send jet requests with headers

### DIFF
--- a/lib/jet_plugin_sdk/jet_client/graphql_client.ex
+++ b/lib/jet_plugin_sdk/jet_client/graphql_client.ex
@@ -22,9 +22,14 @@ defmodule JetPluginSDK.GraphQLClient do
   def query(url, query_string, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 15_000)
     variables = Keyword.get(opts, :variables, %{})
+    headers = Keyword.get(opts, :headers, [])
 
     req =
-      [url: url, connect_options: [timeout: timeout]]
+      [
+        url: url,
+        connect_options: [timeout: timeout],
+        headers: headers
+      ]
       |> Req.new()
       |> AbsintheClient.attach(graphql: {query_string, variables})
       |> accept_graphql_json()

--- a/lib/jet_plugin_sdk/tenant_man/warm_up.ex
+++ b/lib/jet_plugin_sdk/tenant_man/warm_up.ex
@@ -51,7 +51,11 @@ defmodule JetPluginSDK.TenantMan.WarmUp do
   end
 
   defp start_tenants(instances, tenant_module) do
-    Enum.each(instances, fn instance ->
+    instances
+    |> Stream.filter(fn instance ->
+      normalize_state(instance.state) === :enabled
+    end)
+    |> Enum.each(fn instance ->
       %{
         tenant_id: tenant_id,
         config: config,
@@ -74,6 +78,6 @@ defmodule JetPluginSDK.TenantMan.WarmUp do
     end)
   end
 
+  defp normalize_state("CREATED"), do: :created
   defp normalize_state("ENABLED"), do: :enabled
-  defp normalize_state("DISABLED"), do: :disabled
 end


### PR DESCRIPTION
`x-jet-plugin-api-key` is required when requesting
