### PR TITLE
fix: tenant state

### DIFF
--- a/lib/jet_plugin_sdk/tenant_man/tenants/tenant.ex
+++ b/lib/jet_plugin_sdk/tenant_man/tenants/tenant.ex
@@ -98,7 +98,8 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:ok, tenant_state} ->
         Storage.update!(state.tenant_module, %{
           tenant
-          | config: config,
+          | state: :running,
+            config: config,
             capabilities: capabilities
         })
 
@@ -109,7 +110,8 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:ok, tenant_state, extra} ->
         Storage.update!(state.tenant_module, %{
           tenant
-          | config: config,
+          | state: :running,
+            config: config,
             capabilities: capabilities
         })
 
@@ -304,7 +306,8 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
 
         Storage.update!(state.tenant_module, %{
           tenant
-          | config: config,
+          | state: :running,
+            config: config,
             capabilities: capabilities
         })
 
@@ -336,7 +339,8 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
 
         Storage.update!(state.tenant_module, %{
           tenant
-          | config: config,
+          | state: :running,
+            config: config,
             capabilities: capabilities
         })
 

--- a/lib/jet_plugin_sdk/tenant_man/tenants/tenant.ex
+++ b/lib/jet_plugin_sdk/tenant_man/tenants/tenant.ex
@@ -138,16 +138,18 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
         }
 
       {:error, reason} ->
-        Logger.debug(describe(state) <> " updation failed: #{inspect(reason)}.")
-
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
+        Logger.debug(
+          describe(state) <>
+            " updation failed: #{inspect(reason)}, the config and capabilities are not updated."
+        )
 
         {:reply, {:error, reason}, state}
 
       {:error, reason, extra} ->
-        Logger.debug(describe(state) <> " updation failed: #{inspect(reason)}.")
-
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
+        Logger.debug(
+          describe(state) <>
+            " updation failed: #{inspect(reason)}, the config and capabilities are not updated."
+        )
 
         {:reply, {:error, reason}, state, extra}
     end
@@ -184,16 +186,18 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
         {:reply, :async, state, {:continue, {:"$tenant_man", {:uninstall_async, async, extra}}}}
 
       {:error, reason} ->
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
-        Logger.debug(describe(state) <> " uninstallation failed: #{inspect(reason)}.")
+        Logger.debug(
+          describe(state) <>
+            " uninstallation failed: #{inspect(reason)}, the instance is not uninstalled."
+        )
 
         {:reply, {:error, reason}, state}
 
       {:error, reason, extra} ->
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
-        Logger.debug(describe(state) <> " uninstallation failed: #{inspect(reason)}.")
+        Logger.debug(
+          describe(state) <>
+            " uninstallation failed: #{inspect(reason)}, the instance is not uninstalled."
+        )
 
         {:reply, {:error, reason}, state, extra}
     end
@@ -311,9 +315,10 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:error, reason} ->
         report_update_result(tenant.id, reason, state)
 
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
-        Logger.debug(describe(state) <> " asynchronous updation failed: #{inspect(reason)}.")
+        Logger.debug(
+          describe(state) <>
+            " asynchronous updation failed: #{inspect(reason)}, the config and capabilities are not updated."
+        )
 
         {:noreply, state}
     end
@@ -342,9 +347,10 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:error, reason} ->
         report_update_result(tenant.id, reason, state)
 
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
-        Logger.debug(describe(state) <> " asynchronous updation failed: #{inspect(reason)}.")
+        Logger.debug(
+          describe(state) <>
+            " asynchronous updation failed: #{inspect(reason)}, the config and capabilities are not updated."
+        )
 
         {:noreply, state, extra}
     end
@@ -366,10 +372,9 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:error, reason} ->
         report_uninstall_result(tenant.id, reason, state)
 
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
         Logger.debug(
-          describe(state) <> " asynchronous uninstallation failed: #{inspect(reason)}."
+          describe(state) <>
+            " asynchronous uninstallation failed: #{inspect(reason)}, the instance is not uninstalled."
         )
 
         {:noreply, state}
@@ -392,10 +397,9 @@ defmodule JetPluginSDK.TenantMan.Tenants.Tenant do
       {:error, reason} ->
         report_uninstall_result(tenant.id, reason, state)
 
-        Storage.update!(state.tenant_module, %{tenant | state: :error_occurred})
-
         Logger.debug(
-          describe(state) <> " asynchronous uninstallation failed: #{inspect(reason)}."
+          describe(state) <>
+            " asynchronous uninstallation failed: #{inspect(reason)}, the instance is not uninstalled."
         )
 
         {:noreply, state, extra}

--- a/test/jet_plugin_sdk/tenant_man/tenants/async_tenant_test.exs
+++ b/test/jet_plugin_sdk/tenant_man/tenants/async_tenant_test.exs
@@ -81,7 +81,7 @@ defmodule JetPluginSDK.TenantMan.Tenants.AsyncTenantTest do
                %JetPluginSDK.Tenant{
                  config: %{name: "foo"},
                  capabilities: [],
-                 state: :error_occurred
+                 state: :running
                },
                @tenant_module.fetch_tenant(ctx.tenant.id)
              )
@@ -127,7 +127,7 @@ defmodule JetPluginSDK.TenantMan.Tenants.AsyncTenantTest do
                %JetPluginSDK.Tenant{
                  config: %{name: "uninstall"},
                  capabilities: [],
-                 state: :error_occurred
+                 state: :running
                },
                @tenant_module.fetch_tenant(ctx.tenant.id)
              )

--- a/test/jet_plugin_sdk/tenant_man/tenants/naive_tenant_test.exs
+++ b/test/jet_plugin_sdk/tenant_man/tenants/naive_tenant_test.exs
@@ -99,7 +99,7 @@ defmodule JetPluginSDK.TenantMan.Tenants.NaiveTenantTest do
                %JetPluginSDK.Tenant{
                  config: %{name: "foo"},
                  capabilities: [],
-                 state: :error_occurred
+                 state: :running
                },
                @tenant_module.fetch!(ctx.tenant.id)
              )
@@ -135,7 +135,7 @@ defmodule JetPluginSDK.TenantMan.Tenants.NaiveTenantTest do
                %JetPluginSDK.Tenant{
                  config: %{name: "uninstall"},
                  capabilities: [],
-                 state: :error_occurred
+                 state: :running
                },
                @tenant_module.fetch!(ctx.tenant.id)
              )


### PR DESCRIPTION
- **fix: prevent changing state to error_occurred on the life-cycle callback failed**
- **fix: update tenant to running after a successful updation**

只有收到 plugin 主动的 error_occurred 的 log，才会 tenant 的 state 改成 error_occurred，详见 https://www.notion.so/byzanteam/Plugin-b2e51d732b9c45279276a19cfb6afcaf?pvs=4#a9c0c958a9614fb782fc9bc229650c66
