### PR TITLE
chore: set code owners for dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+mix.lock @Byzanteam/jet-elixir

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,3 @@ updates:
       timezone: Asia/Shanghai
     open-pull-requests-limit: 1
     target-branch: main
-    reviewers:
-      - "@Byzanteam/jet-elixir"


### PR DESCRIPTION
Reference https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/